### PR TITLE
Add tests to ensure that admission matches the CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/openshift/crd-schema-checker
 go 1.20
 
 require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/google/uuid v1.3.0
 	github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
 	github.com/openshift/generic-admission-server v1.14.1-0.20230511131000-6e8e035e4fe8
 	github.com/spf13/cobra v1.7.0
@@ -11,6 +13,7 @@ require (
 	k8s.io/api v0.27.1
 	k8s.io/apiextensions-apiserver v0.27.1
 	k8s.io/apimachinery v0.27.1
+	k8s.io/apiserver v0.27.1
 	k8s.io/cli-runtime v0.27.1
 	k8s.io/client-go v0.27.1
 	k8s.io/component-base v0.27.1
@@ -27,7 +30,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.4.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
@@ -47,7 +49,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
@@ -103,7 +104,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiserver v0.27.1 // indirect
 	k8s.io/kms v0.27.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect

--- a/pkg/cmd/checkadmission/admission_tester.go
+++ b/pkg/cmd/checkadmission/admission_tester.go
@@ -1,0 +1,132 @@
+package checkadmission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/openshift/crd-schema-checker/pkg/resourceread"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/google/uuid"
+
+	"github.com/openshift/crd-schema-checker/pkg/manifestcomparators"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/client-go/rest"
+)
+
+type admissionComparatorTest struct {
+	restClient     rest.Interface
+	ComparatorTest manifestcomparators.ComparatorTest
+}
+
+func (tc *admissionComparatorTest) Test(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	admissionReview := &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID: types.UID(uuid.New().String()),
+			Kind: metav1.GroupVersionKind{
+				Group:   apiextensionsv1.SchemeGroupVersion.Group,
+				Version: apiextensionsv1.SchemeGroupVersion.Version,
+				Kind:    "CustomResourceDefinition",
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    apiextensionsv1.SchemeGroupVersion.Group,
+				Version:  apiextensionsv1.SchemeGroupVersion.Version,
+				Resource: "customresourcedefinitions",
+			},
+			SubResource:        "",
+			RequestSubResource: "",
+			UserInfo:           v1.UserInfo{},
+			Object: runtime.RawExtension{
+				Raw: []byte(resourceread.WriteCustomResourceDefinitionV1OrDie(tc.ComparatorTest.NewCRD)),
+			},
+			DryRun:  nil,
+			Options: runtime.RawExtension{},
+		},
+	}
+	if tc.ComparatorTest.ExistingCRD == nil {
+		admissionReview.Request.Operation = admissionv1.Create
+	} else {
+		admissionReview.Request.Operation = admissionv1.Update
+		admissionReview.Request.OldObject = runtime.RawExtension{
+			Raw: []byte(resourceread.WriteCustomResourceDefinitionV1OrDie(tc.ComparatorTest.ExistingCRD)),
+		}
+		admissionReview.Request.Name = tc.ComparatorTest.ExistingCRD.Name
+	}
+
+	admissionBytes, err := json.Marshal(admissionReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := &admissionv1.AdmissionReview{}
+	result := tc.restClient.Post().AbsPath("/apis/admission.api.openshift.io/v1/crdextendedvalidations").Body(admissionBytes).Do(ctx)
+	if body, err := result.Raw(); err != nil {
+		t.Log(string(body))
+		t.Fatal(err)
+	}
+	err = result.Into(actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual.Request = nil
+
+	actualResults := []manifestcomparators.ComparisonResults{}
+	actualErrors := []error{}
+	comparatorNameToResults := map[string]manifestcomparators.ComparisonResults{}
+
+	if actual.Response.Result != nil && actual.Response.Result.Details != nil {
+		for _, cause := range actual.Response.Result.Details.Causes {
+			name := string(cause.Type)
+			if name == "EvaluationError" {
+				actualErrors = append(actualErrors, fmt.Errorf(cause.Message))
+				continue
+			}
+			results := comparatorNameToResults[name]
+			results.Name = name
+			results.Errors = append(results.Errors, cause.Message)
+			comparatorNameToResults[name] = results
+		}
+	}
+
+	for _, warning := range actual.Response.Warnings {
+		if strings.HasPrefix(warning, "fyi: ") {
+			parts := strings.SplitN(warning, ":", 3)
+			name := parts[1]
+			results := comparatorNameToResults[name]
+			results.Name = name
+			results.Infos = append(results.Infos, parts[2])
+			comparatorNameToResults[name] = results
+			continue
+		}
+		parts := strings.SplitN(warning, ":", 2)
+		name := parts[0]
+		results := comparatorNameToResults[name]
+		results.Name = name
+		results.Warnings = append(results.Warnings, parts[1])
+		comparatorNameToResults[name] = results
+	}
+
+	for name := range comparatorNameToResults {
+		results := comparatorNameToResults[name]
+		actualResults = append(actualResults, results)
+	}
+
+	tc.ComparatorTest.Test(t, actualResults, actualErrors)
+}

--- a/pkg/cmd/checkadmission/check_admission.go
+++ b/pkg/cmd/checkadmission/check_admission.go
@@ -21,10 +21,10 @@ type AdmissionCheckOptions struct {
 
 func NewAdmissionCheckOptions(streams genericclioptions.IOStreams) *AdmissionCheckOptions {
 	o := &AdmissionCheckOptions{
-		AdmissionServerOptions: server.NewAdmissionServerOptions(streams.Out, streams.ErrOut),
-		ComparatorOptions:      options.NewComparatorOptions(),
-		admissionHook:          &admissionevaluator.AdmissionHook{},
+		ComparatorOptions: options.NewComparatorOptions(),
+		admissionHook:     &admissionevaluator.AdmissionHook{},
 	}
+	o.AdmissionServerOptions = server.NewAdmissionServerOptions(streams.Out, streams.ErrOut, o.admissionHook)
 
 	return o
 }
@@ -83,7 +83,7 @@ func (o *AdmissionCheckOptions) Validate(args []string) error {
 }
 
 func (o AdmissionCheckOptions) RunAdmissionServer(stopCh <-chan struct{}) error {
-	if err := o.RunAdmissionServer(stopCh); err != nil {
+	if err := o.AdmissionServerOptions.RunAdmissionServer(stopCh); err != nil {
 		return err
 	}
 

--- a/pkg/manifestcomparators/simple_tester.go
+++ b/pkg/manifestcomparators/simple_tester.go
@@ -13,8 +13,8 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-func AllTestsInDir(registry CRDComparatorRegistry, directory string) ([]*comparatorTest, error) {
-	ret := []*comparatorTest{}
+func AllTestsInDir(directory string) ([]ComparatorTest, error) {
+	ret := []ComparatorTest{}
 	err := filepath.WalkDir(directory, func(path string, info os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -35,7 +35,7 @@ func AllTestsInDir(registry CRDComparatorRegistry, directory string) ([]*compara
 			return err
 		}
 
-		currTest, err := TestInDir(registry, relativePath, path)
+		currTest, err := TestInDir(relativePath, path)
 		if err != nil {
 			return err
 		}
@@ -50,11 +50,10 @@ func AllTestsInDir(registry CRDComparatorRegistry, directory string) ([]*compara
 	return ret, nil
 }
 
-func AllTestsInDirForComparator(comparator CRDComparator, directory string) ([]*comparatorTest, error) {
+func AllTestsInDirForComparator(comparator CRDComparator, directory string) ([]*simpleComparatorTest, error) {
 	registry := NewRegistry()
 	registry.AddComparator(comparator)
-
-	return AllTestsInDir(registry, directory)
+	return AllTestsInDirForRegistry(registry, directory)
 }
 
 func RunAllTestsInDirForComparator(t *testing.T, comparator CRDComparator, directory string) {
@@ -64,68 +63,84 @@ func RunAllTestsInDirForComparator(t *testing.T, comparator CRDComparator, direc
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, test.Test)
+		t.Run(test.ComparatorTest.Name, test.Test)
 	}
 }
 
 func RunAllTestsInDirForRegistry(t *testing.T, registry CRDComparatorRegistry, directory string) {
-	tests, err := AllTestsInDir(registry, directory)
+	tests, err := AllTestsInDirForRegistry(registry, directory)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, test.Test)
+		t.Run(test.ComparatorTest.Name, test.Test)
 	}
 }
 
-func TestInDir(registry CRDComparatorRegistry, testName, directory string) (*comparatorTest, error) {
-	ret := &comparatorTest{
-		name:     testName,
-		registry: registry,
+func AllTestsInDirForRegistry(registry CRDComparatorRegistry, directory string) ([]*simpleComparatorTest, error) {
+	tests, err := AllTestsInDir(directory)
+	if err != nil {
+		return nil, err
+	}
+	ret := []*simpleComparatorTest{}
+
+	for i := range tests {
+		ret = append(ret, &simpleComparatorTest{
+			ComparatorTest: tests[i],
+			registry:       registry,
+		})
+	}
+
+	return ret, nil
+}
+
+func TestInDir(testName, directory string) (ComparatorTest, error) {
+	ret := ComparatorTest{
+		Name: testName,
 	}
 
 	optionalExistingCRDFile := filepath.Join(directory, "existing.yaml")
 	existingBytes, err := os.ReadFile(optionalExistingCRDFile)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, err
+		return ComparatorTest{}, err
 	}
 	if len(existingBytes) > 0 {
 		crd, err := resourceread.ReadCustomResourceDefinitionV1(existingBytes)
 		if err != nil {
-			return nil, err
+			return ComparatorTest{}, err
 		}
-		ret.existingCRD = crd
+		ret.ExistingCRD = crd
 	}
 
 	requiredNewCRDFile := filepath.Join(directory, "new.yaml")
 	newBytes, err := os.ReadFile(requiredNewCRDFile)
 	if err != nil {
-		return nil, err
+		return ComparatorTest{}, err
 	}
 	newCRD, err := resourceread.ReadCustomResourceDefinitionV1(newBytes)
 	if err != nil {
-		return nil, err
+		return ComparatorTest{}, err
 	}
-	ret.newCRD = newCRD
+	ret.NewCRD = newCRD
 
 	optionalExpectedFile := filepath.Join(directory, "expected.yaml")
 	expectedBytes, err := os.ReadFile(optionalExpectedFile)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, err
+		return ComparatorTest{}, err
 	}
 	if len(expectedBytes) > 0 {
 		expected := &ComparisonResultsList{}
 		if err := yaml.Unmarshal(expectedBytes, expected); err != nil {
-			return nil, err
+			return ComparatorTest{}, err
 		}
-		ret.expectedResults = expected.Items
+		ret.ExpectedResults = expected.Items
 	}
 
 	optionalExpectedErrorsFile := filepath.Join(directory, "errors.txt")
 	expectedErrorsBytes, err := os.ReadFile(optionalExpectedErrorsFile)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, err
+		return ComparatorTest{}, err
 	}
 	if len(expectedErrorsBytes) > 0 {
 		expectedErrors := []string{}
@@ -134,9 +149,9 @@ func TestInDir(registry CRDComparatorRegistry, testName, directory string) (*com
 			expectedErrors = append(expectedErrors, scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
-			return nil, err
+			return ComparatorTest{}, err
 		}
-		ret.expectedErrors = expectedErrors
+		ret.ExpectedErrors = expectedErrors
 	}
 
 	return ret, nil
@@ -159,32 +174,41 @@ type ComparisonResultsList struct {
 	Items []ComparisonResults `yaml:"items"`
 }
 
-type comparatorTest struct {
-	name        string
-	registry    CRDComparatorRegistry
-	existingCRD *apiextensionsv1.CustomResourceDefinition
-	newCRD      *apiextensionsv1.CustomResourceDefinition
+// ComparatorTest represents the directory style test we have.
+type ComparatorTest struct {
+	Name        string
+	ExistingCRD *apiextensionsv1.CustomResourceDefinition
+	NewCRD      *apiextensionsv1.CustomResourceDefinition
 
-	expectedResults []ComparisonResults
-	expectedErrors  []string
+	ExpectedResults []ComparisonResults
+	ExpectedErrors  []string
 }
 
-func (tc *comparatorTest) Test(t *testing.T) {
-	actualResults, actualErrors := tc.registry.Compare(tc.existingCRD, tc.newCRD)
+type simpleComparatorTest struct {
+	ComparatorTest ComparatorTest
+	registry       CRDComparatorRegistry
+}
+
+func (tc *simpleComparatorTest) Test(t *testing.T) {
+	actualResults, actualErrors := tc.registry.Compare(tc.ComparatorTest.ExistingCRD, tc.ComparatorTest.NewCRD)
+	tc.ComparatorTest.Test(t, actualResults, actualErrors)
+}
+
+func (tc *ComparatorTest) Test(t *testing.T, actualResults []ComparisonResults, actualErrors []error) {
 	switch {
-	case len(tc.expectedErrors) == 0 && len(actualErrors) == 0:
-	case len(tc.expectedErrors) == 0 && len(actualErrors) != 0:
+	case len(tc.ExpectedErrors) == 0 && len(actualErrors) == 0:
+	case len(tc.ExpectedErrors) == 0 && len(actualErrors) != 0:
 		t.Fatalf("0 errors expected, got %v", actualErrors)
-	case len(tc.expectedErrors) != 0 && len(actualErrors) == 0:
-		t.Fatalf("expected some errors: %v, got none", tc.expectedErrors)
-	case len(tc.expectedErrors) != 0 && len(actualErrors) != 0:
-		if !reflect.DeepEqual(tc.expectedErrors, actualErrors) {
-			t.Fatalf("expected some errors: %v, got different errors: %v", tc.expectedErrors, actualErrors)
+	case len(tc.ExpectedErrors) != 0 && len(actualErrors) == 0:
+		t.Fatalf("expected some errors: %v, got none", tc.ExpectedErrors)
+	case len(tc.ExpectedErrors) != 0 && len(actualErrors) != 0:
+		if !reflect.DeepEqual(tc.ExpectedErrors, actualErrors) {
+			t.Fatalf("expected some errors: %v, got different errors: %v", tc.ExpectedErrors, actualErrors)
 		}
 	}
 
 	// check to be sure that every expected message appeared
-	for _, expected := range tc.expectedResults {
+	for _, expected := range tc.ExpectedResults {
 		expectedBytes, err := yaml.Marshal(expected)
 		if err != nil {
 			t.Error(err)
@@ -205,13 +229,16 @@ func (tc *comparatorTest) Test(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if !reflect.DeepEqual(expected.Errors, actual.Errors) {
+		noErrorsAsExpected := len(expected.Errors) == 0 && len(actual.Errors) == 0
+		if !noErrorsAsExpected && !reflect.DeepEqual(expected.Errors, actual.Errors) {
 			t.Errorf("mismatched errors for expectedResults[%v]: expected\n%v\n, got\n%v\n", expected.Name, string(expectedBytes), string(actualBytes))
 		}
-		if !reflect.DeepEqual(expected.Warnings, actual.Warnings) {
+		noWarningsAsExpected := len(expected.Warnings) == 0 && len(actual.Warnings) == 0
+		if !noWarningsAsExpected && !reflect.DeepEqual(expected.Warnings, actual.Warnings) {
 			t.Errorf("mismatched warnings for expectedResults[%v]: expected\n%v\n, got\n%v\n", expected.Name, string(expectedBytes), string(actualBytes))
 		}
-		if !reflect.DeepEqual(expected.Infos, actual.Infos) {
+		noInfosAsExpected := len(expected.Infos) == 0 && len(actual.Infos) == 0
+		if !noInfosAsExpected && !reflect.DeepEqual(expected.Infos, actual.Infos) {
 			t.Errorf("mismatched infos for expectedResults[%v]: expected\n%v\n, got\n%v\n", expected.Name, string(expectedBytes), string(actualBytes))
 		}
 	}
@@ -223,7 +250,7 @@ func (tc *comparatorTest) Test(t *testing.T) {
 			t.Error(err)
 		}
 
-		expectedPtr := findResultsForComparator(actual.Name, tc.expectedResults)
+		expectedPtr := findResultsForComparator(actual.Name, tc.ExpectedResults)
 		if expectedPtr == nil {
 			// this is only an error when we expect a message
 			if len(actual.Errors) == 0 && len(actual.Warnings) == 0 && len(actual.Infos) == 0 {
@@ -238,13 +265,16 @@ func (tc *comparatorTest) Test(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if !reflect.DeepEqual(expected.Errors, actual.Errors) {
+		noErrorsAsExpected := len(expected.Errors) == 0 && len(actual.Errors) == 0
+		if !noErrorsAsExpected && !reflect.DeepEqual(expected.Errors, actual.Errors) {
 			t.Errorf("mismatched errors for expectedResults[%v]: expected\n%v\n, got\n%v\n", expected.Name, string(expectedBytes), string(actualBytes))
 		}
-		if !reflect.DeepEqual(expected.Warnings, actual.Warnings) {
+		noWarningsAsExpected := len(expected.Warnings) == 0 && len(actual.Warnings) == 0
+		if !noWarningsAsExpected && !reflect.DeepEqual(expected.Warnings, actual.Warnings) {
 			t.Errorf("mismatched warnings for expectedResults[%v]: expected\n%v\n, got\n%v\n", expected.Name, string(expectedBytes), string(actualBytes))
 		}
-		if !reflect.DeepEqual(expected.Infos, actual.Infos) {
+		noInfosAsExpected := len(expected.Infos) == 0 && len(actual.Infos) == 0
+		if !noInfosAsExpected && !reflect.DeepEqual(expected.Infos, actual.Infos) {
 			t.Errorf("mismatched infos for expectedResults[%v]: expected\n%v\n, got\n%v\n", expected.Name, string(expectedBytes), string(actualBytes))
 		}
 	}

--- a/pkg/resourceread/apiextensions.go
+++ b/pkg/resourceread/apiextensions.go
@@ -31,3 +31,7 @@ func ReadCustomResourceDefinitionV1OrDie(objBytes []byte) *apiextensionsv1.Custo
 	}
 	return requiredObj.(*apiextensionsv1.CustomResourceDefinition)
 }
+
+func WriteCustomResourceDefinitionV1OrDie(obj *apiextensionsv1.CustomResourceDefinition) string {
+	return runtime.EncodeOrDie(apiExtensionsCodecs.LegacyCodec(apiextensionsv1.SchemeGroupVersion), obj)
+}


### PR DESCRIPTION
Add testing for the admission server.  This re-uses the same test definition and comparison handling as the CLI tests to ensure equivalence of the two.

/assign @JoelSpeed 