### PR TITLE
add requirement for SSA tags on lists

### DIFF
--- a/pkg/defaultcomparators/interfaces.go
+++ b/pkg/defaultcomparators/interfaces.go
@@ -14,22 +14,19 @@ func NewDefaultComparators() manifestcomparators.CRDComparatorRegistry {
 	must(ret.AddComparator(manifestcomparators.NoFieldRemoval()))
 	must(ret.AddComparator(manifestcomparators.NoMaps()))
 	must(ret.AddComparator(manifestcomparators.MustHaveStatus()))
+	must(ret.AddComparator(manifestcomparators.ListsMustHaveSSATags()))
 
 	/*
 		other useful comparators
 
-		1. don't remove field
 		2. don't change field types
 		3. don't tighten validation rules
 		4. don't loosen validation rules (warning)
-		5. status subresource must be used if status exists
 		6. conditions must match metav1.Conditions with proper SSA tags
 		7. all lists must have SSA tags
-		8. don't use maps
 		9. don't use floats
 		10. don't use unsigned ints
 		11. no durations (for kube, openshift configuration API allowed)
-		12. don't use bools
 		13. enumerated values should use CamelCase
 		14. optional should be pointers (for kube, openshift configuration API allowed)
 		15. no new fields can be required

--- a/pkg/manifestcomparators/comp_lists_must_have_ssa_tags.go
+++ b/pkg/manifestcomparators/comp_lists_must_have_ssa_tags.go
@@ -1,0 +1,59 @@
+package manifestcomparators
+
+import (
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+type listsMustHaveSSATags struct{}
+
+func ListsMustHaveSSATags() CRDComparator {
+	return listsMustHaveSSATags{}
+}
+
+func (listsMustHaveSSATags) Name() string {
+	return "ListsMustHaveSSATags"
+}
+
+func (listsMustHaveSSATags) WhyItMatters() string {
+	return "Lists require x-kubernetes-list-type tags in order to properly merge different requests from different field managers.  " +
+		"Valid value are 'atomic', 'set', and 'map' and are indicated in kubebuilder tags with '// +listType=<val>' and " +
+		"'// +listMapKey=<val>'."
+}
+
+func (b listsMustHaveSSATags) Validate(crd *apiextensionsv1.CustomResourceDefinition) (ComparisonResults, error) {
+	errsToReport := []string{}
+
+	for _, newVersion := range crd.Spec.Versions {
+		fieldsWithoutListType := []string{}
+		SchemaHas(newVersion.Schema.OpenAPIV3Schema, field.NewPath("^"), field.NewPath("^"), func(s *apiextensionsv1.JSONSchemaProps, fldPath, simpleLocation *field.Path) bool {
+			if s.Type != "array" {
+				return false
+			}
+			if s.XListType == nil || len(*s.XListType) == 0 {
+				fieldsWithoutListType = append(fieldsWithoutListType, simpleLocation.String())
+			}
+			return false
+		})
+
+		for _, newMapField := range fieldsWithoutListType {
+			errsToReport = append(errsToReport, fmt.Sprintf("crd/%v version/%v field/%v must set x-kubernetes-list-type", crd.Name, newVersion.Name, newMapField))
+		}
+
+	}
+
+	return ComparisonResults{
+		Name:         b.Name(),
+		WhyItMatters: b.WhyItMatters(),
+
+		Errors:   errsToReport,
+		Warnings: nil,
+		Infos:    nil,
+	}, nil
+}
+
+func (b listsMustHaveSSATags) Compare(existingCRD, newCRD *apiextensionsv1.CustomResourceDefinition) (ComparisonResults, error) {
+	return RatchetCompare(b, existingCRD, newCRD)
+}

--- a/pkg/manifestcomparators/comp_lists_must_have_ssa_tags_test.go
+++ b/pkg/manifestcomparators/comp_lists_must_have_ssa_tags_test.go
@@ -1,0 +1,7 @@
+package manifestcomparators
+
+import "testing"
+
+func TestListsMustHaveSSATags(t *testing.T) {
+	RunAllTestsInDirForComparator(t, ListsMustHaveSSATags(), "testdata/lists_must_have_ssa_tags")
+}

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed-and-another/existing.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed-and-another/existing.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                badList:
+                  description: badList is wrong, but pre-existing
+                  type: array
+                  items:
+                    type: object

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed-and-another/expected.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed-and-another/expected.yaml
@@ -1,0 +1,6 @@
+items:
+  - name: ListsMustHaveSSATags
+    errors:
+      - crd/thepluralresource.api.example.com version/v1 field/^.spec.newBadList must set x-kubernetes-list-type
+    warnings: []
+    infos: []

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed-and-another/new.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed-and-another/new.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                badList:
+                  description: badList is wrong, but pre-existing
+                  type: array
+                  items:
+                    type: object
+                newBadList:
+                  description: newBadList will fail validation
+                  type: array
+                  items:
+                    type: object
+

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed/existing.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed/existing.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                badList:
+                  description: badList is wrong, but pre-existing
+                  type: array
+                  items:
+                    type: object

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed/expected.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed/expected.yaml
@@ -1,0 +1,5 @@
+items:
+  - name: ListsMustHaveSSATags
+    errors: []
+    warnings: []
+    infos: []

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed/new.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/missing-tag-already-existed/new.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                badList:
+                  description: badList is wrong, but pre-existing
+                  type: array
+                  items:
+                    type: object

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-empty-tag/expected.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-empty-tag/expected.yaml
@@ -1,0 +1,6 @@
+items:
+  - name: ListsMustHaveSSATags
+    errors:
+      - crd/thepluralresource.api.example.com version/v1 field/^.spec.badList must set x-kubernetes-list-type
+    warnings: []
+    infos: []

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-empty-tag/new.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-empty-tag/new.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                badList:
+                  description: badList will fail validation
+                  type: array
+                  items:
+                    type: object
+                  x-kubernetes-list-type:
+

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-missing-tag/expected.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-missing-tag/expected.yaml
@@ -1,0 +1,6 @@
+items:
+  - name: ListsMustHaveSSATags
+    errors:
+      - crd/thepluralresource.api.example.com version/v1 field/^.spec.badList must set x-kubernetes-list-type
+    warnings: []
+    infos: []

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-missing-tag/new.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-missing-tag/new.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                badList:
+                  description: badList will fail validation
+                  type: array
+                  items:
+                    type: object
+

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-tag-present/expected.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-tag-present/expected.yaml
@@ -1,0 +1,5 @@
+items:
+  - name: ListsMustHaveSSATags
+    errors: []
+    warnings: []
+    infos: []

--- a/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-tag-present/new.yaml
+++ b/pkg/manifestcomparators/testdata/lists_must_have_ssa_tags/new-tag-present/new.yaml
@@ -1,0 +1,52 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                atomicList:
+                  description: ok
+                  type: array
+                  items:
+                    type: object
+                  x-kubernetes-list-type: atomic
+                setList:
+                  description: ok
+                  type: array
+                  items:
+                    type: object
+                  x-kubernetes-list-type: set
+                mapList:
+                  description: ok
+                  type: array
+                  items:
+                    type: object
+                  x-kubernetes-list-type: map
+


### PR DESCRIPTION
This avoids always using the default of atomic, which is often not what is actually desired.