### PR TITLE
Add info/warning level explanation of CEL costs and string/array sizes

### DIFF
--- a/pkg/manifestcomparators/comp_must_not_exceed_cost_budget.go
+++ b/pkg/manifestcomparators/comp_must_not_exceed_cost_budget.go
@@ -142,6 +142,11 @@ func (b mustNotExceedCostBudget) Validate(crd *apiextensionsv1.CustomResourceDef
 
 				return false
 			})
+
+		if rootCELContext != nil && rootCELContext.TotalCost != nil && rootCELContext.TotalCost.Total > apiextensionsvalidation.StaticEstimatedCRDCostLimit {
+			costErrorMsg := getCostErrorMessage("total CRD cost", rootCELContext.TotalCost.Total, apiextensionsvalidation.StaticEstimatedCRDCostLimit)
+			errsToReport = append(errsToReport, field.Forbidden(field.NewPath("^"), costErrorMsg).Error())
+		}
 	}
 
 	return ComparisonResults{
@@ -193,7 +198,7 @@ func getCostErrorMessage(costName string, expressionCost, costLimit uint64) stri
 	} else {
 		factor = fmt.Sprintf("%.1fx", exceedFactor)
 	}
-	return fmt.Sprintf("%s exceeds budget by factor of %s (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)", costName, factor)
+	return fmt.Sprintf("%s exceeds budget by factor of %s (try simplifying the rule(s), or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)", costName, factor)
 }
 
 // extractCELContext takes a series of CEL contextxs and returns the child context of the last schema in the series.

--- a/pkg/manifestcomparators/simple_tester.go
+++ b/pkg/manifestcomparators/simple_tester.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/openshift/crd-schema-checker/pkg/resourceread"
@@ -248,6 +249,14 @@ func (tc *ComparatorTest) Test(t *testing.T, actualResults []ComparisonResults, 
 		if err != nil {
 			t.Error(err)
 		}
+
+		sort.Strings(expected.Errors)
+		sort.Strings(actual.Errors)
+		sort.Strings(expected.Warnings)
+		sort.Strings(actual.Warnings)
+		sort.Strings(expected.Infos)
+		sort.Strings(actual.Infos)
+
 		noErrorsAsExpected := len(expected.Errors) == 0 && len(actual.Errors) == 0
 		if !noErrorsAsExpected && !reflect.DeepEqual(expected.Errors, actual.Errors) {
 			t.Errorf("mismatched errors for expectedResults[%v]: expected\n%v\n, got\n%v\n", expected.Name, string(expectedBytes), string(actualBytes))

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/cel_cannot_compile/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/cel_cannot_compile/expected.yaml
@@ -7,3 +7,6 @@ items:
        | ...........^
     warnings:
     infos:
+    - '^.spec.badCELList: Array has maxItems of 2048.'
+    - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
+      worst case number of times the rule will be evaluated.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/cel_cannot_compile/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/cel_cannot_compile/expected.yaml
@@ -8,5 +8,4 @@ items:
     warnings:
     infos:
     - '^.spec.badCELList: Array has maxItems of 2048.'
-    - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
-      worst case number of times the rule will be evaluated.'
+    - '^.spec.badCELList: Field has a maximum cardinality of 1.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation/expected.yaml
@@ -4,7 +4,6 @@ items:
     warnings:
     infos:
     - '^.spec.badProperty: String has maxLength of 16384.'
-    - '^.spec.badProperty: Field has a maximum cardinality of 1. This is the calculated,
-      worst case number of times the rule will be evaluated.'
+    - '^.spec.badProperty: Field has a maximum cardinality of 1.'
     - '^.spec.badProperty: Rule 0 raw cost is 681617. Estimated total cost of 681617.
-      The maximum allowable value is 10000000.'
+      The maximum allowable value is 10000000. Rule is 6.82% of allowed budget.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation/expected.yaml
@@ -3,7 +3,8 @@ items:
     errors: []
     warnings:
     infos:
+    - '^.spec.badProperty: String has maxLength of 16384.'
     - '^.spec.badProperty: Field has a maximum cardinality of 1. This is the calculated,
-          worst case number of times the rule will be evaluated.'
-    - '^.spec.badProperty: Rule 0 Rule 0 raw cost is 681617. Estimated total cost of 681617. The maximum allowable
-          value is 10000000.'
+      worst case number of times the rule will be evaluated.'
+    - '^.spec.badProperty: Rule 0 raw cost is 681617. Estimated total cost of 681617.
+      The maximum allowable value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation/expected.yaml
@@ -3,3 +3,7 @@ items:
     errors: []
     warnings:
     infos:
+    - '^.spec.badProperty: Field has a maximum cardinality of 1. This is the calculated,
+          worst case number of times the rule will be evaluated.'
+    - '^.spec.badProperty: Rule 0 Rule 0 raw cost is 681617. Estimated total cost of 681617. The maximum allowable
+          value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_bounded_list/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_bounded_list/expected.yaml
@@ -3,3 +3,7 @@ items:
     errors: []
     warnings:
     infos:
+    - '^.spec.badList[*].badProperty: Field has a maximum cardinality of 10. This is the
+          calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.badList[*].badProperty: Rule 0 raw cost is 681617. Estimated total cost
+          of 6816170. The maximum allowable value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_bounded_list/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_bounded_list/expected.yaml
@@ -7,4 +7,4 @@ items:
     - '^.spec.badList[*].badProperty: Field has a maximum cardinality of 10. This is the
       calculated, worst case number of times the rule will be evaluated.'
     - '^.spec.badList[*].badProperty: Rule 0 raw cost is 681617. Estimated total cost
-      of 6816170. The maximum allowable value is 10000000.'
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_bounded_list/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_bounded_list/expected.yaml
@@ -3,7 +3,8 @@ items:
     errors: []
     warnings:
     infos:
+    - '^.spec.badList[*].badProperty: String has maxLength of 16384.'
     - '^.spec.badList[*].badProperty: Field has a maximum cardinality of 10. This is the
-          calculated, worst case number of times the rule will be evaluated.'
+      calculated, worst case number of times the rule will be evaluated.'
     - '^.spec.badList[*].badProperty: Rule 0 raw cost is 681617. Estimated total cost
-          of 6816170. The maximum allowable value is 10000000.'
+      of 6816170. The maximum allowable value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_unbounded_list/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_unbounded_list/expected.yaml
@@ -6,4 +6,9 @@ items:
           the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and
           strings are declared)'
     warnings:
+    - '^.spec.badList[*].badProperty: Field has unbounded cardinality. At least one, variable
+          parent field does not have a maxItems or maxProperties constraint: ^.spec.badList.
+          Falling back to CEL calculated worst case of 1048576 executions.'
     infos:
+    - '^.spec.badList[*].badProperty: Rule 0 raw cost is 681617. Estimated total cost
+          of 714727227392. The maximum allowable value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_unbounded_list/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_unbounded_list/expected.yaml
@@ -10,5 +10,6 @@ items:
           parent field does not have a maxItems or maxProperties constraint: ^.spec.badList.
           Falling back to CEL calculated worst case of 1048576 executions.'
     infos:
+    - '^.spec.badList[*].badProperty: String has maxLength of 16384.'
     - '^.spec.badList[*].badProperty: Rule 0 raw cost is 681617. Estimated total cost
           of 714727227392. The maximum allowable value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_unbounded_list/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_unbounded_list/expected.yaml
@@ -3,8 +3,11 @@ items:
     errors:
     - '^.properties[spec].properties[badList].items.properties[badProperty]: Forbidden:
           estimated rule cost exceeds budget by factor of more than 100x (try simplifying
-          the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and
-          strings are declared)'
+          the rule(s), or adding maxItems, maxProperties, and maxLength where arrays, maps,
+          and strings are declared)'
+    - '^: Forbidden: total CRD cost exceeds budget by factor of more than 100x (try simplifying
+          the rule(s), or adding maxItems, maxProperties, and maxLength where arrays, maps,
+          and strings are declared)'
     warnings:
     - '^.spec.badList[*].badProperty: Field has unbounded cardinality. At least one, variable
           parent field does not have a maxItems or maxProperties constraint: ^.spec.badList.

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_unbounded_list/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/limited_budget_x_validation_in_unbounded_list/expected.yaml
@@ -12,4 +12,5 @@ items:
     infos:
     - '^.spec.badList[*].badProperty: String has maxLength of 16384.'
     - '^.spec.badList[*].badProperty: Rule 0 raw cost is 681617. Estimated total cost
-          of 714727227392. The maximum allowable value is 10000000.'
+          of 714727227392. The maximum allowable value is 10000000. Rule is 7147272.27% of
+          allowed budget.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_limited_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_limited_budget_x_validation/expected.yaml
@@ -4,7 +4,6 @@ items:
     warnings:
     infos:
     - '^.spec.badCELList: Array has maxItems of 2048.'
-    - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
-          worst case number of times the rule will be evaluated.'
+    - '^.spec.badCELList: Field has a maximum cardinality of 1.'
     - '^.spec.badCELList: Rule 0 raw cost is 5916674. Estimated total cost of 5916674. The maximum allowable
-          value is 10000000.'
+          value is 10000000. Rule is 59.17% of allowed budget.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_limited_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_limited_budget_x_validation/expected.yaml
@@ -3,3 +3,7 @@ items:
     errors: []
     warnings:
     infos:
+    - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
+          worst case number of times the rule will be evaluated.'
+    - '^.spec.badCELList: Rule 0 raw cost is 5916674. Estimated total cost of 5916674. The maximum allowable
+          value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_limited_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_limited_budget_x_validation/expected.yaml
@@ -3,6 +3,7 @@ items:
     errors: []
     warnings:
     infos:
+    - '^.spec.badCELList: Array has maxItems of 2048.'
     - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
           worst case number of times the rule will be evaluated.'
     - '^.spec.badCELList: Rule 0 raw cost is 5916674. Estimated total cost of 5916674. The maximum allowable

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_over_budget_x_validation/expected.yaml
@@ -3,8 +3,11 @@ items:
     errors:
     - '^.properties[spec].properties[badCELList]: Forbidden:
           estimated rule cost exceeds budget by factor of more than 100x (try simplifying
-          the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and
-          strings are declared)'
+          the rule(s), or adding maxItems, maxProperties, and maxLength where arrays, maps,
+          and strings are declared)'
+    - '^: Forbidden: total CRD cost exceeds budget by factor of more than 100x (try simplifying
+          the rule(s), or adding maxItems, maxProperties, and maxLength where arrays, maps,
+          and strings are declared)'
     warnings:
     - '^.spec.badCELList: Array has unbounded maxItems. It will be considered to have
           262143 items. Consider adding a maxItems constraint to reduce the raw rule cost.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_over_budget_x_validation/expected.yaml
@@ -9,7 +9,6 @@ items:
     - '^.spec.badCELList: Array has unbounded maxItems. It will be considered to have
           262143 items. Consider adding a maxItems constraint to reduce the raw rule cost.'
     infos:
-    - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
-          worst case number of times the rule will be evaluated.'
+    - '^.spec.badCELList: Field has a maximum cardinality of 1.'
     - '^.spec.badCELList: Rule 0 raw cost is 2308968389009. Estimated total cost of 2308968389009. The maximum allowable
-          value is 10000000.'
+          value is 10000000. Rule is 23089683.89% of allowed budget.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_over_budget_x_validation/expected.yaml
@@ -7,3 +7,7 @@ items:
           strings are declared)'
     warnings:
     infos:
+    - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
+          worst case number of times the rule will be evaluated.'
+    - '^.spec.badCELList: Rule 0 raw cost is 2308968389009. Estimated total cost of 2308968389009. The maximum allowable
+          value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_over_budget_x_validation/expected.yaml
@@ -6,6 +6,8 @@ items:
           the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and
           strings are declared)'
     warnings:
+    - '^.spec.badCELList: Array has unbounded maxItems. It will be considered to have
+          262143 items. Consider adding a maxItems constraint to reduce the raw rule cost.'
     infos:
     - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
           worst case number of times the rule will be evaluated.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/multi_validation_exceeds_total_crd_budget/existing.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/multi_validation_exceeds_total_crd_budget/existing.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/multi_validation_exceeds_total_crd_budget/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/multi_validation_exceeds_total_crd_budget/expected.yaml
@@ -1,0 +1,83 @@
+items:
+  - name: MustNotExceedCostBudget
+    errors:
+    - '^: Forbidden: total CRD cost exceeds budget by factor of 1.022425x (try simplifying
+          the rule(s), or adding maxItems, maxProperties, and maxLength where arrays, maps,
+          and strings are declared)'
+    warnings:
+    infos:
+    - '^.spec.firstList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.firstList[*].longProperty: Field has a maximum cardinality of 10. This is the
+      calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.firstList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.secondList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.secondList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.secondList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.thirdList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.thirdList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.thirdList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.fourthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.fourthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.fourthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.fifthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.fifthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.fifthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.sixthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.sixthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.sixthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.seventhList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.seventhList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.seventhList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.eighthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.eighthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.eighthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.ninthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.ninthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.ninthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.tenthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.tenthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.tenthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.eleventhList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.eleventhList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.eleventhList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.twelfthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.twelfthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.twelfthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.thirteenthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.thirteenthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.thirteenthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.fourteenthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.fourteenthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.fourteenthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'
+    - '^.spec.fifteenthList[*].longProperty: String has maxLength of 16384.'
+    - '^.spec.fifteenthList[*].longProperty: Field has a maximum cardinality of 10. This
+      is the calculated, worst case number of times the rule will be evaluated.'
+    - '^.spec.fifteenthList[*].longProperty: Rule 0 raw cost is 681617. Estimated total cost
+      of 6816170. The maximum allowable value is 10000000. Rule is 68.16% of allowed budget.'  

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/multi_validation_exceeds_total_crd_budget/new.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/multi_validation_exceeds_total_crd_budget/new.yaml
@@ -1,0 +1,333 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                firstList:
+                  description: firstList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                secondList:
+                  description: secondList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                thirdList:
+                  description: thirdList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                fourthList:
+                  description: fourthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                fifthList:
+                  description: fifthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                sixthList:
+                  description: sixthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                seventhList:
+                  description: seventhList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                eighthList:
+                  description: eightList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                ninthList:
+                  description: ninthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                tenthList:
+                  description: tenthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                eleventhList:
+                  description: eleventhList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                twelfthList:
+                  description: twelthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                thirteenthList:
+                  description: thirteenthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                fourteenthList:
+                  description: fourteenthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty
+                fifteenthList:
+                  description: fifteenthList is acceptable, it has a maxItems limit
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  items:
+                    type: object
+                    properties:
+                      longProperty:
+                        description: longProperty has a complex validation with a long length limit
+                        type: string
+                        maxLength: 16384
+                        x-kubernetes-validations:
+                        - rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$|^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                      okProperty:
+                        description: okProperty is fine, it has no CEL validations
+                        type: string
+                        minLength: 8
+                    required:
+                      - longProperty

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/over_budget_x_validation/expected.yaml
@@ -2,7 +2,7 @@ items:
   - name: MustNotExceedCostBudget
     errors:
     - '^.properties[spec].properties[badProperty]: Forbidden:
-          estimated rule cost exceeds budget by factor of 3.3x (try simplifying the rule,
+          estimated rule cost exceeds budget by factor of 3.3x (try simplifying the rule(s),
           or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings
           are declared)'
     warnings:

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/over_budget_x_validation/expected.yaml
@@ -7,3 +7,7 @@ items:
           are declared)'
     warnings:
     infos:
+    - '^.spec.badProperty: Field has a maximum cardinality of 1. This is the calculated,
+          worst case number of times the rule will be evaluated.'
+    - '^.spec.badProperty: Rule 0 raw cost is 32715593. Estimated total cost of 32715593. The maximum allowable
+          value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/over_budget_x_validation/expected.yaml
@@ -6,6 +6,8 @@ items:
           or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings
           are declared)'
     warnings:
+    - '^.spec.badProperty: String has unbounded maxLength. It will be considered to have
+          length 3145726. Consider adding a maxLength constraint to reduce the raw rule cost.'
     infos:
     - '^.spec.badProperty: Field has a maximum cardinality of 1. This is the calculated,
           worst case number of times the rule will be evaluated.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/over_budget_x_validation/expected.yaml
@@ -9,7 +9,6 @@ items:
     - '^.spec.badProperty: String has unbounded maxLength. It will be considered to have
           length 3145726. Consider adding a maxLength constraint to reduce the raw rule cost.'
     infos:
-    - '^.spec.badProperty: Field has a maximum cardinality of 1. This is the calculated,
-          worst case number of times the rule will be evaluated.'
+    - '^.spec.badProperty: Field has a maximum cardinality of 1.'
     - '^.spec.badProperty: Rule 0 raw cost is 32715593. Estimated total cost of 32715593. The maximum allowable
-          value is 10000000.'
+          value is 10000000. Rule is 327.16% of allowed budget.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/existing.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/existing.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/expected.yaml
@@ -1,0 +1,15 @@
+items:
+  - name: MustNotExceedCostBudget
+    errors:
+    - '^.properties[spec].properties[badCELList]: Forbidden:
+          estimated rule cost exceeds budget by factor of more than 100x (try simplifying
+          the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and
+          strings are declared)'
+    warnings:
+    - '^.spec.badCELList: Array has unbounded maxItems. It will be considered to have
+          1048575 items. Consider adding a maxItems constraint to reduce the raw rule cost.'
+    infos:
+    - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
+          worst case number of times the rule will be evaluated.'
+    - '^.spec.badCELList: Rule 0 raw cost is 3028284602. Estimated total cost of 3028284602.
+          The maximum allowable value is 10000000.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/expected.yaml
@@ -9,7 +9,6 @@ items:
     - '^.spec.badCELList: Array has unbounded maxItems. It will be considered to have
           1048575 items. Consider adding a maxItems constraint to reduce the raw rule cost.'
     infos:
-    - '^.spec.badCELList: Field has a maximum cardinality of 1. This is the calculated,
-          worst case number of times the rule will be evaluated.'
+    - '^.spec.badCELList: Field has a maximum cardinality of 1.'
     - '^.spec.badCELList: Rule 0 raw cost is 3028284602. Estimated total cost of 3028284602.
-          The maximum allowable value is 10000000.'
+          The maximum allowable value is 10000000. Rule is 30282.85% of allowed budget.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/expected.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/expected.yaml
@@ -1,10 +1,12 @@
 items:
   - name: MustNotExceedCostBudget
     errors:
-    - '^.properties[spec].properties[badCELList]: Forbidden:
-          estimated rule cost exceeds budget by factor of more than 100x (try simplifying
-          the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and
-          strings are declared)'
+     - '^.properties[spec].properties[badCELList]: Forbidden: estimated rule cost exceeds
+          budget by factor of more than 100x (try simplifying the rule(s), or adding maxItems,
+          maxProperties, and maxLength where arrays, maps, and strings are declared)'
+     - '^: Forbidden: total CRD cost exceeds budget by factor of 30.3x (try simplifying
+          the rule(s), or adding maxItems, maxProperties, and maxLength where arrays, maps,
+          and strings are declared)'
     warnings:
     - '^.spec.badCELList: Array has unbounded maxItems. It will be considered to have
           1048575 items. Consider adding a maxItems constraint to reduce the raw rule cost.'

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/new.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/new.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                badCELList:
+                  description: badProperty is wrong, as it has overly complex CEL validations and no limits
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                  - rule: self.all(x, x.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$'))
+                  items:
+                    type: string
+                    maxLength: 256
+                okProperty:
+                  description: okProperty is fine, it has no CEL validations
+                  type: string
+                  minLength: 8
+              required:
+                - badCElList

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/new.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/new.yaml
@@ -44,5 +44,3 @@ spec:
                   description: okProperty is fine, it has no CEL validations
                   type: string
                   minLength: 8
-              required:
-                - badCElList

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/new.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/string_list_over_budget_x_validation/new.yaml
@@ -32,7 +32,7 @@ spec:
               type: object
               properties:
                 badCELList:
-                  description: badProperty is wrong, as it has overly complex CEL validations and no limits
+                  description: badCELList is wrong, as it has overly complex CEL validations and no limits
                   type: array
                   x-kubernetes-list-type: atomic
                   x-kubernetes-validations:


### PR DESCRIPTION
The idea behind this change is to try and help users of schema checker understand what is contributing to their rule cost.

Reporting cardinality and raw rule cost makes it easy to determine if the rule is contributing massively to the total cost, or whether the cardinality is.

Reporting when there is unbounded cardinality, or an unbounded field length, or an array missing maxItems will give users an idea of the worst case estimates for the sizes of these things when they have not set a maximum themselves, hopefully showing that there's plenty of headroom for them to improve the validation cost by setting some limits.

This isn't complete, as we aren't showing when array items are contributing massively, eg array has a rule inspecting the items, where the items is an unbounded length string. I intend to follow up to report that . That will help cases like `list_over_budget_x_validation`.