### PR TITLE
Ignore schemas that do not have XValidations

### DIFF
--- a/pkg/manifestcomparators/comp_must_not_exceed_cost_budget.go
+++ b/pkg/manifestcomparators/comp_must_not_exceed_cost_budget.go
@@ -54,6 +54,11 @@ func (b mustNotExceedCostBudget) Validate(crd *apiextensionsv1.CustomResourceDef
 					return false
 				}
 
+				if schema.XValidations == nil {
+					// There are no XValidations at this level, we do not need to continue with checks.
+					return false
+				}
+
 				schemaInfos, schemaWarnings, err := inspectSchema(schema, simpleLocation, len(ancestry) == 0)
 				if err != nil {
 					errsToReport = append(errsToReport, err.Error())
@@ -280,10 +285,6 @@ func isUnboundedCardinality(schema *apiextensions.JSONSchemaProps) bool {
 }
 
 func inspectSchema(schema *apiextensions.JSONSchemaProps, simpleLocation *field.Path, isRoot bool) ([]string, []string, error) {
-	if schema.XValidations == nil {
-		return nil, nil, nil
-	}
-
 	typeInfo, err := getDeclType(schema, isRoot)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_limited_budget_x_validation/new.yaml
+++ b/pkg/manifestcomparators/testdata/must_not_exceed_cost_budget/list_limited_budget_x_validation/new.yaml
@@ -49,6 +49,12 @@ spec:
                         description: value is the value for the key
                         type: string
                         maxLength: 1024
+                      doubleEnum:
+                        allOf:
+                        - enum: ["a", "b", "c"]
+                        - enum: ["a", "b", "c"]
+                        description: doubleEnum is an enum with duplicate enum markers that have not been flattened.
+                        type: string
                     required:
                     - key
                 okProperty:


### PR DESCRIPTION
Found out that the `TypeInfo` call will fail if the subset of the schema that is being checked does not have a `type` set. In some cases, a schema will not have a `type`, eg when it is a member of an `allOf` of some other property.

Looking at the two portions of the checks that actually implement reports here, they check if `schema.XValidations` is non-empty before continuing, and return early.

Moving this check up a level and earlier saves us from trying to access type info on schemas that we don't need to actually inspect, and avoids the error `unable to convert structural schema to CEL declarations`