### PR TITLE
Jv run checks according to labels

### DIFF
--- a/pkg/manifestcomparators/comp_conditions_must_have_proper_ssa_tags.go
+++ b/pkg/manifestcomparators/comp_conditions_must_have_proper_ssa_tags.go
@@ -18,6 +18,10 @@ func (conditionsMustHaveProperSSATags) Name() string {
 	return "ConditionsMustHaveProperSSATags"
 }
 
+func (conditionsMustHaveProperSSATags) Labels() []string {
+	return []string{Style.String()}
+}
+
 func (conditionsMustHaveProperSSATags) WhyItMatters() string {
 	return "Conditions should follow the standard schema included in  " +
 		"https://github.com/kubernetes/apimachinery/blob/release-1.29/pkg/apis/meta/v1/types.go#L1482-L1542" +

--- a/pkg/manifestcomparators/comp_lists_must_have_ssa_tags.go
+++ b/pkg/manifestcomparators/comp_lists_must_have_ssa_tags.go
@@ -17,6 +17,10 @@ func (listsMustHaveSSATags) Name() string {
 	return "ListsMustHaveSSATags"
 }
 
+func (listsMustHaveSSATags) Labels() []string {
+	return []string{Style.String()}
+}
+
 func (listsMustHaveSSATags) WhyItMatters() string {
 	return "Lists require x-kubernetes-list-type tags in order to properly merge different requests from different field managers.  " +
 		"Valid value are 'atomic', 'set', and 'map' and are indicated in kubebuilder tags with '// +listType=<val>' and " +

--- a/pkg/manifestcomparators/comp_must_have_status.go
+++ b/pkg/manifestcomparators/comp_must_have_status.go
@@ -17,6 +17,10 @@ func (mustHaveStatus) Name() string {
 	return "MustHaveStatus"
 }
 
+func (mustHaveStatus) Labels() []string {
+	return []string{Style.String()}
+}
+
 func (mustHaveStatus) WhyItMatters() string {
 	return "When the schema has a status field, it should be controlled via a status suberesource for different permissions " +
 		"to control those who can control desired state from those who can control the actual state."

--- a/pkg/manifestcomparators/comp_must_not_exceed_cost_budget.go
+++ b/pkg/manifestcomparators/comp_must_not_exceed_cost_budget.go
@@ -28,6 +28,10 @@ func (mustNotExceedCostBudget) Name() string {
 	return "MustNotExceedCostBudget"
 }
 
+func (mustNotExceedCostBudget) Labels() []string {
+	return []string{Style.String()}
+}
+
 func (mustNotExceedCostBudget) WhyItMatters() string {
 	return ""
 }

--- a/pkg/manifestcomparators/comp_no_bools.go
+++ b/pkg/manifestcomparators/comp_no_bools.go
@@ -17,6 +17,10 @@ func (noBools) Name() string {
 	return "NoBools"
 }
 
+func (noBools) Labels() []string {
+	return []string{DataType.String(), Style.String()}
+}
+
 func (noBools) WhyItMatters() string {
 	return "Booleans rarely stay booleans and can never develop new options.  This frequently leads to cases where there " +
 		"are multiple boolean fields, with some combinations of values not being allowed.  Additionally, strings provide " +

--- a/pkg/manifestcomparators/comp_no_enum_removal.go
+++ b/pkg/manifestcomparators/comp_no_enum_removal.go
@@ -18,6 +18,10 @@ func (noEnumRemoval) Name() string {
 	return "NoEnumRemoval"
 }
 
+func (noEnumRemoval) Labels() []string {
+	return []string{BackwardsCompatibility.String()}
+}
+
 func (noEnumRemoval) WhyItMatters() string {
 	return "If enums are removed, then clients that use those enum values will not be able to upgrade to the newest CRD."
 }

--- a/pkg/manifestcomparators/comp_no_field_removal.go
+++ b/pkg/manifestcomparators/comp_no_field_removal.go
@@ -18,6 +18,10 @@ func (noFieldRemoval) Name() string {
 	return "NoFieldRemoval"
 }
 
+func (noFieldRemoval) Labels() []string {
+	return []string{BackwardsCompatibility.String()}
+}
+
 func (noFieldRemoval) WhyItMatters() string {
 	return "If fields are removed, then clients that rely on those fields will not be able to read them or write them."
 }

--- a/pkg/manifestcomparators/comp_no_floats.go
+++ b/pkg/manifestcomparators/comp_no_floats.go
@@ -17,6 +17,10 @@ func (noFloats) Name() string {
 	return "NoFloats"
 }
 
+func (noFloats) Labels() []string {
+	return []string{DataType.String(), Style.String()}
+}
+
 func (noFloats) WhyItMatters() string {
 	return "Floating-point values cannot be reliably round-tripped (encoded and re-decoded) without changing, " +
 		"and have varying precision and representations across languages and architectures."

--- a/pkg/manifestcomparators/comp_no_maps.go
+++ b/pkg/manifestcomparators/comp_no_maps.go
@@ -17,6 +17,10 @@ func (noMaps) Name() string {
 	return "NoMaps"
 }
 
+func (noMaps) Labels() []string {
+	return []string{DataType.String(), Style.String()}
+}
+
 func (noMaps) WhyItMatters() string {
 	return "When serialized into yaml or json, maps don't have \"names\" associated with their key.  This makes " +
 		"it less obvious what the key of map means or what is for.  Additionally, maps are not guaranteed stable " +

--- a/pkg/manifestcomparators/comp_no_new_required_fields.go
+++ b/pkg/manifestcomparators/comp_no_new_required_fields.go
@@ -19,6 +19,10 @@ func (noNewRequiredFields) Name() string {
 	return "NoNewRequiredFields"
 }
 
+func (noNewRequiredFields) Labels() []string {
+	return []string{BackwardsCompatibility.String()}
+}
+
 func (noNewRequiredFields) WhyItMatters() string {
 	return "If new fields are required, then old clients will not function properly.  Even if CRD defaulting is used, " +
 		"CRD defaulting requires allowing an object with an empty or missing value to then get defaulted."

--- a/pkg/manifestcomparators/comp_no_uints.go
+++ b/pkg/manifestcomparators/comp_no_uints.go
@@ -17,6 +17,10 @@ func (noUints) Name() string {
 	return "NoUints"
 }
 
+func (noUints) Labels() []string {
+	return []string{DataType.String(), Style.String()}
+}
+
 func (noUints) WhyItMatters() string {
 	return "Unsigned integers don't have consistent support across languages and libraries."
 }

--- a/pkg/manifestcomparators/interfaces.go
+++ b/pkg/manifestcomparators/interfaces.go
@@ -13,6 +13,7 @@ type ComparisonResults struct {
 
 type CRDComparator interface {
 	Name() string
+	Labels() []string
 	WhyItMatters() string
 	Compare(existingCRD, newCRD *apiextensionsv1.CustomResourceDefinition) (ComparisonResults, error)
 }
@@ -26,7 +27,29 @@ type CRDComparatorRegistry interface {
 	GetComparator(name string) (CRDComparator, error)
 
 	KnownComparators() []string
+	ComparatorsMatchingLabels(labels []string) []string
 	AllComparators() []CRDComparator
 
 	Compare(existingCRD, newCRD *apiextensionsv1.CustomResourceDefinition, names ...string) ([]ComparisonResults, []error)
+}
+
+type LabelEnum int
+
+const (
+	BackwardsCompatibility LabelEnum = iota
+	DataType
+	Style
+)
+
+func (l LabelEnum) String() string {
+	switch l {
+	case BackwardsCompatibility:
+		return "BackwardsCompatibility"
+	case DataType:
+		return "DataType"
+	case Style:
+		return "Style"
+	default:
+		return "Unknown"
+	}
 }

--- a/pkg/manifestcomparators/registry.go
+++ b/pkg/manifestcomparators/registry.go
@@ -40,6 +40,26 @@ func (r *crdComparatorRegistry) KnownComparators() []string {
 	return keys.List()
 }
 
+func (r *crdComparatorRegistry) ComparatorsMatchingLabels(labels []string) []string {
+	names := make([]string, 0)
+	labelsMap := make(map[string]interface{})
+
+	for _, label := range labels {
+		labelsMap[label] = struct{}{}
+	}
+
+	for name, comparator := range r.comparators {
+		for _, label := range comparator.Labels() {
+			if _, ok := labelsMap[label]; ok {
+				names = append(names, name)
+				break
+			}
+		}
+	}
+
+	return names
+}
+
 func (r *crdComparatorRegistry) AllComparators() []CRDComparator {
 	ret := []CRDComparator{}
 


### PR DESCRIPTION
This PR will likely not be merged as reaching consensus on what labels to assign is difficult, and these checks may be divided into separate repos anyways. This PR should probably be closed. There is another PR that also makes it easier to select which checks should be run using wildcards here https://github.com/openshift/crd-schema-checker/pull/39 

This PR adds the ability to select which checks are run using labels. Available labels are `BackwardsCompatibility`, `DataType`, and `Style`. This is useful, because some users might not agree with checks for such things as floating-point values, but want to ensure backwards compatibility. Currently to run a subset of checks a user must specify a list of checks that they don't want to run using `--disabled-validators`. The `--enabled-validators` flag doesn't work for selecting a subset of checks, because it only adds to the list of default checks, which already encompasses all checks. Even if `--enabled-validators` did work it would be desirable to be able to select checks by label, since it makes it easy to run subsets of checks without manually going through all of the checks and investigating which involve backwards compatibility and which involve datatypes that are not recommended, and writing a long command line that names all of the checks involving backwards compatibility. This is also useful as more checks with a specific label are added, those checks will be run without the user needing to check if new checks have been added that are of the type they would like to run. The new  flag works with both `--disabled-validators` and `--enabled-validators`. `--disabled-validators` can be used to turn off selected checks matching the specified labels. `--enabled-validators` can be used to select additional checks not matching the specified labels.

### Testing

```
crd-schema-checker check-manifests  --help
Statically compare two manifests for incompatible schemas

Usage:
  crd-schema-checker check-manifests [flags]

Flags:
      --disabled-validators strings    list of comparators that must be disabled
      --enabled-validators strings     list of comparators that must be enabled
      --existing-crd-filename string   file of existing CRD
  -h, --help                           help for check-manifests
      --labels strings                 comparators with matching labels will be enabled
      --new-crd-filename string        file of new CRD

Global Flags:
      --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
  -v, --v Level                        number for the log level verbosity
      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)
```

The new flag appears in the help message.

For testing CRDs from the operator/config/crd/bases directory in the `stackrox/stackrox` repository were used.

```
crd-schema-checker check-manifests --new-crd-filename=platform.stackrox.io_securedclusters.yaml
```

Resulted in errors of type 

ConditionsMustHaveProperSSATags
ListsMustHaveSSATags
NoBools
NoMaps

Whereas 

```
crd-schema-checker check-manifests --new-crd-filename=platform.stackrox.io_securedclusters.yaml --labels=DataType
```

Resulted in errors of type

NoBools
NoMaps

```
crd-schema-checker check-manifests --new-crd-filename=platform.stackrox.io_securedclusters.yaml --labels=Style
```

Resulted in errors of type 

ConditionsMustHaveProperSSATags
ListsMustHaveSSATags
NoBools
NoMaps

This is because currently all checks with the `DataType` label also has the `Style` label.

```
crd-schema-checker check-manifests --new-crd-filename=platform.stackrox.io_securedclusters.yaml --labels=BackwardsCompatibility
```

Resulted in no errors

```
crd-schema-checker check-manifests --new-crd-filename=platform.stackrox.io_securedclusters.yaml --labels=Style --disabled-validators=ConditionsMustHaveProperSSATags
```

Resulted in errors of type

ListsMustHaveSSATags
NoBools
NoMaps

```
crd-schema-checker check-manifests --new-crd-filename=platform.stackrox.io_securedclusters.yaml --labels=BackwardsCompatibility --enabled-validators=ConditionsMustHaveProperSSATags
```

Resulted in errors of type `ConditionsMustHaveProperSSATags`

#### Comparing CRDs

A new CRD was created from an existing one, with an enum removed and a new boolean field. The difference was the following
```
diff platform.stackrox.io_securedclusters.yaml platform.stackrox.io_securedclusters_bad.yaml
59d58
<                     - Disabled
68a68,71
>                   fakeForTesting:
>                     default: false
>                     description: Just for testing
>                     type: boolean
```

The following were run

```crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml
ERROR: "NoBools": crd/securedclusters.platform.stackrox.io version/v1alpha1 field/^.spec.admissionControl.fakeForTesting may not be a boolean
ERROR: "NoEnumRemoval": crd/securedclusters.platform.stackrox.io version/v1alpha1 enum/"Disabled" may not be removed for field/^.spec.admissionControl.bypass
```

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml --labels=BackwardsCompatibility
ERROR: "NoEnumRemoval": crd/securedclusters.platform.stackrox.io version/v1alpha1 enum/"Disabled" may not be removed for field/^.spec.admissionControl.bypass
```

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml --labels=DataType
ERROR: "NoBools": crd/securedclusters.platform.stackrox.io version/v1alpha1 field/^.spec.admissionControl.fakeForTesting may not be a boolean
```

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml --labels=DataType,BackwardsCompatibility
ERROR: "NoBools": crd/securedclusters.platform.stackrox.io version/v1alpha1 field/^.spec.admissionControl.fakeForTesting may not be a boolean
ERROR: "NoEnumRemoval": crd/securedclusters.platform.stackrox.io version/v1alpha1 enum/"Disabled" may not be removed for field/^.spec.admissionControl.bypass
```