### PR TITLE
ROX-27909: Improve how crd schema checker checks are selected

### DIFF
--- a/pkg/cmd/options/comparators.go
+++ b/pkg/cmd/options/comparators.go
@@ -2,6 +2,8 @@ package options
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -11,11 +13,13 @@ import (
 )
 
 type ComparatorOptions struct {
-	ComparatorRegistry        manifestcomparators.CRDComparatorRegistry
-	KnownComparators          []string
-	DefaultEnabledComparators []string
-	EnabledComparators        []string
-	DisabledComparators       []string
+	ComparatorRegistry          manifestcomparators.CRDComparatorRegistry
+	KnownComparators            []string
+	DefaultEnabledComparators   []string
+	EnabledComparators          []string
+	DisabledComparators         []string
+	DisabledComparatorWildcards []string
+	EnabledComparatorWildcards  []string
 }
 
 func NewComparatorOptions() *ComparatorOptions {
@@ -31,8 +35,8 @@ func NewComparatorOptions() *ComparatorOptions {
 }
 
 func (o *ComparatorOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringSliceVar(&o.DisabledComparators, "disabled-validators", o.DisabledComparators, "list of comparators that must be disabled")
-	fs.StringSliceVar(&o.EnabledComparators, "enabled-validators", o.EnabledComparators, "list of comparators that must be enabled")
+	fs.StringSliceVar(&o.DisabledComparatorWildcards, "disabled-validators", o.DisabledComparatorWildcards, "list of comparators that must be disabled. May contain wildcards")
+	fs.StringSliceVar(&o.EnabledComparatorWildcards, "enabled-validators", o.EnabledComparatorWildcards, "list of comparators that must be enabled. May contain wildcards")
 }
 
 func (o *ComparatorOptions) Validate() error {
@@ -50,11 +54,42 @@ func (o *ComparatorOptions) Validate() error {
 	return nil
 }
 
+func (o *ComparatorOptions) comparatorWildcardsToComparators(comparatorWildcards []string) []string {
+	matchingComparators := make([]string, 0)
+
+	for _, known := range o.KnownComparators {
+		for _, wildcard := range comparatorWildcards {
+			if known == wildcard {
+				matchingComparators = append(matchingComparators, known)
+				break
+			}
+			if matched, _ := path.Match(wildcard, known); matched {
+				matchingComparators = append(matchingComparators, known)
+				break
+			}
+		}
+	}
+
+	return matchingComparators
+}
+
+func containsWildcards(comparatorWildcards []string) bool {
+	for _, wildcard := range comparatorWildcards {
+		if strings.ContainsAny(wildcard, "*") {
+			return true
+		}
+	}
+	return false
+}
+
 // Complete fills in missing values before command execution.
 func (o *ComparatorOptions) Complete() (*ComparatorConfig, error) {
 	ret := &ComparatorConfig{
 		ComparatorRegistry: o.ComparatorRegistry,
 	}
+
+	o.DisabledComparators = o.comparatorWildcardsToComparators(o.DisabledComparatorWildcards)
+	o.EnabledComparators = o.comparatorWildcardsToComparators(o.EnabledComparatorWildcards)
 
 	knownComparators := sets.NewString(o.KnownComparators...)
 	disabledComparators := sets.NewString(o.DisabledComparators...)
@@ -67,7 +102,25 @@ func (o *ComparatorOptions) Complete() (*ComparatorConfig, error) {
 		return nil, fmt.Errorf("unknown comparators: %v", disabledComparators.List())
 	}
 
-	comparatorsToRun := sets.NewString(o.DefaultEnabledComparators...).Insert(o.EnabledComparators...).Delete(o.DisabledComparators...)
+	disabledContainsWildcards := containsWildcards(o.DisabledComparatorWildcards)
+	enabledContainsWildcards := containsWildcards(o.EnabledComparatorWildcards)
+
+	comparatorsToRun := sets.NewString()
+
+	if disabledContainsWildcards {
+		comparatorsToRun = sets.NewString(o.DefaultEnabledComparators...).Delete(o.DisabledComparators...).Insert(o.EnabledComparators...)
+	} else if !disabledContainsWildcards && enabledContainsWildcards {
+		comparatorsToRun = sets.NewString(o.DefaultEnabledComparators...).Insert(o.EnabledComparators...).Delete(o.DisabledComparators...)
+	} else if len(o.EnabledComparators) == 0 && len(o.DisabledComparators) != 0 {
+		comparatorsToRun = sets.NewString(o.DefaultEnabledComparators...).Delete(o.DisabledComparators...)
+	} else if len(o.EnabledComparators) == 0 && len(o.DisabledComparators) == 0 {
+		comparatorsToRun = sets.NewString(o.DefaultEnabledComparators...)
+	} else if len(o.EnabledComparators) != 0 && len(o.DisabledComparators) == 0 {
+		return nil, fmt.Errorf("Enabling comparators without disabling comparators has no effect. Consider using a wildcard for enabled comparators")
+	} else if !disabledContainsWildcards && !enabledContainsWildcards {
+		return nil, fmt.Errorf("Cannot both disable and enable comparators if neither of them has a wildcard")
+	}
+
 	ret.ComparatorNames = comparatorsToRun.List()
 
 	return ret, nil


### PR DESCRIPTION
Currently to run a subset of checks a user must specify a list of checks that they don't want to run using --disabled-validators. The --enabled-validators flag doesn't work for selecting a subset of checks, because it only adds to the list of default checks, which already encompasses all checks. 

This PR makes it possible to select checks using wildcards.


### Testing

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml 
ERROR: "NoBools": crd/securedclusters.platform.stackrox.io version/v1alpha1 field/^.spec.admissionControl.fakeForTesting may not be a boolean
ERROR: "NoEnumRemoval": crd/securedclusters.platform.stackrox.io version/v1alpha1 enum/"Disabled" may not be removed for field/^.spec.admissionControl.bypass
```

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml --disabled-validators=* --enabled-validators=NoBools
ERROR: "NoBools": crd/securedclusters.platform.stackrox.io version/v1alpha1 field/^.spec.admissionControl.fakeForTesting may not be a boolean
```

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml --disabled-validators=* --enabled-validators=NoEnumRemoval
ERROR: "NoEnumRemoval": crd/securedclusters.platform.stackrox.io version/v1alpha1 enum/"Disabled" may not be removed for field/^.spec.admissionControl.bypass
```

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml --disabled-validators=NoBools --enabled-validators=*
ERROR: "NoEnumRemoval": crd/securedclusters.platform.stackrox.io version/v1alpha1 enum/"Disabled" may not be removed for field/^.spec.admissionControl.bypass
```

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml --disabled-validators=NoEnumRemoval --enabled-validators=*
ERROR: "NoBools": crd/securedclusters.platform.stackrox.io version/v1alpha1 field/^.spec.admissionControl.fakeForTesting may not be a boolean
```

```
crd-schema-checker check-manifests  --existing-crd-filename=platform.stackrox.io_securedclusters.yaml --new-crd-filename=platform.stackrox.io_securedclusters_bad.yaml --enabled-validators=NoEnumRemoval
F0201 14:50:20.707940  694737 check_manifests.go:50] Enabling comparators without disabling comparators has no effect. Consider using a wildcard for enabled comparators
```