### PR TITLE
fix: allow new required field with new optional parent and existing grandparent

### DIFF
--- a/pkg/manifestcomparators/comp_no_new_required_fields.go
+++ b/pkg/manifestcomparators/comp_no_new_required_fields.go
@@ -24,6 +24,32 @@ func (noNewRequiredFields) WhyItMatters() string {
 		"CRD defaulting requires allowing an object with an empty or missing value to then get defaulted."
 }
 
+// isFieldOptional checks if a field is optional (nullable or not required by its parent)
+func isFieldOptional(
+	s *apiextensionsv1.JSONSchemaProps,
+	ancestors []*apiextensionsv1.JSONSchemaProps,
+	fldPath *field.Path,
+	newToFldPath map[*apiextensionsv1.JSONSchemaProps]*field.Path,
+	newFldPathToRequiredFields map[string]sets.Set[string]) bool {
+
+	if s.Nullable {
+		return true
+	}
+
+	// Check if field is not required by its parent
+	if len(ancestors) > 0 {
+		parentOfField := ancestors[len(ancestors)-1]
+		groups := lastIndexOrKeyRegexp.FindStringSubmatch(fldPath.String())
+		if len(groups) == 2 {
+			lastStep := groups[1]
+			parentRequiredFields := newFldPathToRequiredFields[newToFldPath[parentOfField].String()]
+			return !parentRequiredFields.Has(lastStep)
+		}
+	}
+
+	return false
+}
+
 func (b noNewRequiredFields) Compare(existingCRD, newCRD *apiextensionsv1.CustomResourceDefinition) (ComparisonResults, error) {
 	if existingCRD == nil {
 		return ComparisonResults{
@@ -97,10 +123,13 @@ func (b noNewRequiredFields) Compare(existingCRD, newCRD *apiextensionsv1.Custom
 					return false
 				}
 
-				existingRequired, existedBefore := existingRequiredFields[fldPath.String()]
-				if !existedBefore && s.Nullable {
-					// if the parent of the required field (current element) didn't exist in the schema before AND
-					// if the parent of the required field is nullable (client doesn't have to set it),
+				existingRequired, _ := existingRequiredFields[fldPath.String()]
+
+				// Check if this field actually existed in the old schema
+				_, fieldExistedBefore := existingFldPathToJSONSchemaProps[fldPath.String()]
+
+				if !fieldExistedBefore && isFieldOptional(s, ancestors, fldPath, newToFldPath, newFldPathToRequiredFields) {
+					// if the parent of the required field didn't exist before AND is optional,
 					// then we can allow a child to be required.
 					return false
 				}
@@ -150,10 +179,14 @@ func isAnyAncestorNewAndNullable(
 	for i := len(ancestors) - 1; i >= 0; i-- {
 		ancestor := ancestors[i]
 		ancestorFldPath := newToFldPath[ancestor]
+
+		// Check if ancestor is optional (nullable, optional array, or not required by parent)
 		isOptionalArray := ancestor.Type == "array" && (ancestor.MinLength == nil || *ancestor.MinLength == 0)
-		isAncestoryOptional := ancestor.Nullable || isOptionalArray
-		if !isAncestoryOptional {
-			// if this ancestor isn't nullable, then it cannot allow the current element to be required
+		isAncestorOptional := ancestor.Nullable || isOptionalArray ||
+			(i > 0 && isFieldOptional(ancestor, ancestors[:i], ancestorFldPath, newToFldPath, newFldPathToRequiredFields))
+
+		if !isAncestorOptional {
+			// if this ancestor isn't optional, then it cannot allow the current element to be required
 			continue
 		}
 

--- a/pkg/manifestcomparators/testdata/no_new_required_fields/can_require_new_field_of_new_optional_parent_with_existing_grandparent/existing.yaml
+++ b/pkg/manifestcomparators/testdata/no_new_required_fields/can_require_new_field_of_new_optional_parent_with_existing_grandparent/existing.yaml
@@ -30,18 +30,3 @@ spec:
             spec:
               description: spec holds user settable values for configuration
               type: object
-              properties:
-                grandparent:
-                  description: new wrapper
-                  type: object
-                  nullable: true
-                  properties:
-                    parent:
-                      description: new wrapper
-                      type: object
-                      required:
-                        - child
-                      properties:
-                        child:
-                          description: new wrapper
-                          type: object

--- a/pkg/manifestcomparators/testdata/no_new_required_fields/can_require_new_field_of_new_optional_parent_with_existing_grandparent/expected.yaml
+++ b/pkg/manifestcomparators/testdata/no_new_required_fields/can_require_new_field_of_new_optional_parent_with_existing_grandparent/expected.yaml
@@ -1,0 +1,5 @@
+items:
+  - name: NoNewRequiredFields
+    errors: []
+    warnings:
+    infos:

--- a/pkg/manifestcomparators/testdata/no_new_required_fields/can_require_new_field_of_new_optional_parent_with_existing_grandparent/new.yaml
+++ b/pkg/manifestcomparators/testdata/no_new_required_fields/can_require_new_field_of_new_optional_parent_with_existing_grandparent/new.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+            version:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name

--- a/pkg/manifestcomparators/testdata/no_new_required_fields/cannot_require_new_field_of_existing_optional_parent/existing.yaml
+++ b/pkg/manifestcomparators/testdata/no_new_required_fields/cannot_require_new_field_of_existing_optional_parent/existing.yaml
@@ -31,7 +31,6 @@ spec:
               description: spec holds user settable values for configuration
               type: object
               properties:
-                grandparent:
+                parent:
                   description: new wrapper
                   type: object
-                  nullable: true

--- a/pkg/manifestcomparators/testdata/no_new_required_fields/cannot_require_new_field_of_existing_optional_parent/expected.yaml
+++ b/pkg/manifestcomparators/testdata/no_new_required_fields/cannot_require_new_field_of_existing_optional_parent/expected.yaml
@@ -1,7 +1,7 @@
 items:
   - name: NoNewRequiredFields
     errors:
-    - crd/thepluralresource.api.example.com version/v1 field/^.spec.grandparent.parent.child
+    - crd/thepluralresource.api.example.com version/v1 field/^.spec.parent.child
       is new and may not be required
     warnings:
     infos:

--- a/pkg/manifestcomparators/testdata/no_new_required_fields/cannot_require_new_field_of_existing_optional_parent/new.yaml
+++ b/pkg/manifestcomparators/testdata/no_new_required_fields/cannot_require_new_field_of_existing_optional_parent/new.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: thepluralresource.api.example.com
+spec:
+  group: api.example.com
+  names:
+    kind: TheKind
+    listKind: TheKindList
+    plural: thepluralresource
+    singular: thesingularname
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "TheKind is for testing."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                parent:
+                  description: new wrapper
+                  type: object
+                  required:
+                    - child
+                  properties:
+                    child:
+                      description: new wrapper
+                      type: object


### PR DESCRIPTION
That case is actually valid. If we have an existing grandparent, and we add an optional new parent with a new required field, we cannot break existing users because a) the parent is optional, so the required field does not mean users have to set it and b) the parent is new so there can not be previous versions of it that did not set the required field.

Hope I'm not missing anything here. Great project btw, we'd love to use it on our CRDs but we currently can't because of this problem.